### PR TITLE
fix(deploy): use REST API for uploads to control MIME types

### DIFF
--- a/.github/workflows/deploy-dry-run.yml
+++ b/.github/workflows/deploy-dry-run.yml
@@ -294,6 +294,7 @@ jobs:
               -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" \
               -H "apikey: $SUPABASE_SERVICE_ROLE_KEY" \
               -H "Content-Type: application/json" \
+              -H "x-upsert: true" \
               --data-binary @"$TEST_FILE" \
               "${STORAGE_API_URL}/object/website/$TEST_PATH")
             upload_status=$(echo "$upload_response" | tail -n1)

--- a/.github/workflows/deploy-dry-run.yml
+++ b/.github/workflows/deploy-dry-run.yml
@@ -282,18 +282,19 @@ jobs:
           if [ "$bucket_status" = "200" ]; then
             echo "Testing upload capability to 'website' bucket..."
 
-            # Create test file
-            TEST_FILE="/tmp/dry-run-test-$(date +%s).txt"
-            TEST_PATH=".dry-run-test/validate-$(date +%s).txt"
-            echo "dry-run-validation-$(date)" > "$TEST_FILE"
+            # Create test JSON file (using allowed MIME type)
+            TEST_FILE="/tmp/dry-run-test-$(date +%s).json"
+            TEST_PATH=".dry-run-test/validate-$(date +%s).json"
+            echo '{"test": "dry-run-validation", "timestamp": "'$(date -Iseconds)'"}' > "$TEST_FILE"
 
-            # Upload test file
+            # Upload using same method as deploy.yml (--data-binary with explicit Content-Type)
             set +e
             upload_response=$(curl -s -w "\n%{http_code}" \
               -X POST \
               -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" \
               -H "apikey: $SUPABASE_SERVICE_ROLE_KEY" \
-              -F "file=@$TEST_FILE" \
+              -H "Content-Type: application/json" \
+              --data-binary @"$TEST_FILE" \
               "${STORAGE_API_URL}/object/website/$TEST_PATH")
             upload_status=$(echo "$upload_response" | tail -n1)
             upload_body=$(echo "$upload_response" | sed '$d')

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -263,20 +263,59 @@ jobs:
           fi
           echo "Bucket 'website' verified and ready for uploads"
 
-          # Upload function with retry logic
+          # Get MIME type without charset suffix (Supabase Storage rejects charset)
+          get_mime_type() {
+            local file="$1"
+            local ext="${file##*.}"
+            case "$ext" in
+              html) echo "text/html" ;;
+              css) echo "text/css" ;;
+              js) echo "application/javascript" ;;
+              json) echo "application/json" ;;
+              png) echo "image/png" ;;
+              jpg|jpeg) echo "image/jpeg" ;;
+              gif) echo "image/gif" ;;
+              svg) echo "image/svg+xml" ;;
+              webp) echo "image/webp" ;;
+              ico) echo "image/x-icon" ;;
+              woff) echo "font/woff" ;;
+              woff2) echo "font/woff2" ;;
+              map) echo "application/json" ;;
+              *) echo "application/octet-stream" ;;
+            esac
+          }
+
+          # Upload function using REST API with retry logic
+          # Uses REST API directly to control Content-Type header (CLI adds charset which is rejected)
           upload_file() {
             local file="$1"
             local rel_path="$2"
+            local mime_type=$(get_mime_type "$file")
             local max_attempts=3
+
             for attempt in $(seq 1 $max_attempts); do
-              if supabase storage cp --experimental "$file" "ss:///website/$rel_path" 2>&1; then
+              set +e
+              response=$(curl -s -w "\n%{http_code}" \
+                -X POST \
+                -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" \
+                -H "apikey: $SUPABASE_SERVICE_ROLE_KEY" \
+                -H "Content-Type: $mime_type" \
+                -H "x-upsert: true" \
+                --data-binary @"$file" \
+                "${STORAGE_API_URL}/object/website/$rel_path")
+              status=$(echo "$response" | tail -n1)
+              set -e
+
+              if [ "$status" = "200" ] || [ "$status" = "201" ]; then
                 return 0
               fi
+
               if [ "$attempt" -lt "$max_attempts" ]; then
-                echo "Retry $attempt/$max_attempts for $rel_path..."
+                echo "Retry $attempt/$max_attempts for $rel_path (HTTP $status)..."
                 sleep $((attempt * 2))
               fi
             done
+            echo "Failed: $rel_path (HTTP $status)"
             return 1
           }
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -212,7 +212,7 @@ jobs:
                 "name": "website",
                 "public": true,
                 "file_size_limit": 52428800,
-                "allowed_mime_types": ["text/html", "text/css", "application/javascript", "application/json", "image/png", "image/jpeg", "image/gif", "image/svg+xml", "image/webp", "image/x-icon", "font/woff", "font/woff2", "application/font-woff", "application/font-woff2"]
+                "allowed_mime_types": ["text/html", "text/css", "text/plain", "application/javascript", "application/json", "application/octet-stream", "image/png", "image/jpeg", "image/gif", "image/svg+xml", "image/webp", "image/x-icon", "font/woff", "font/woff2", "application/font-woff", "application/font-woff2"]
               }' \
               "${STORAGE_API_URL}/bucket")
             create_status=$(echo "$create_response" | tail -n1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.7] - 2025-12-24
+
+### Fixed
+- Deploy: Use REST API for uploads to control MIME types (Supabase Storage rejects charset suffix)
+- Deploy: Align dry-run upload test with actual deploy method
+
+## [0.1.6] - 2025-12-24
+
+### Fixed
+- Deploy: Use Storage REST API for bucket creation (SQL inserts don't register with Storage service)
+- Deploy: Add proper bucket verification via REST API before uploads
+- Deploy: Remove unreliable `supabase storage ls --experimental` checks
+- Deploy: Add comprehensive dry-run validation
+
 ## [0.1.5] - 2025-12-23
 
 ### Changed

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "community-pulse-frontend",
-  "version": "0.1.1",
+  "version": "0.1.7",
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "community-pulse"
-version = "0.1.5"
+version = "0.1.7"
 description = "Community Pulse backend utilities"
 requires-python = ">=3.10"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -79,7 +79,7 @@ wheels = [
 
 [[package]]
 name = "community-pulse"
-version = "0.1.5"
+version = "0.1.7"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- Fixes upload failures for `.js` and `.html` files with `415 invalid_mime_type` errors
- Replaces `supabase storage cp` CLI with direct REST API calls using curl
- Adds `get_mime_type()` function that returns clean MIME types without charset suffix

## Problem
The Supabase CLI's `storage cp` command auto-detects MIME types and adds `; charset=utf-8` suffix (e.g., `text/javascript; charset=utf-8`). Supabase Storage API rejects these extended MIME types with a 415 error.

## Solution
Use the Storage REST API directly with curl, where we control the exact `Content-Type` header. The custom `get_mime_type` function maps file extensions to clean MIME types.

## Test plan
- [ ] Merge to master and verify deployment workflow succeeds
- [ ] Confirm all 24 static files upload successfully
- [ ] Verify site loads at the Supabase Storage URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)